### PR TITLE
Remove `cleanUpBeforeWriting` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,19 @@ However, this approach leads to the test code and fixture file definitions being
 `@mizdra/inline-fixture-files` allows you to define fixture files in your test code. This makes the test code easier to understand.
 
 ```typescript
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import dedent from 'dedent';
 import { ESLint } from 'eslint';
-import { expect, test } from 'vitest';
+import { expect, test, beforeEach } from 'vitest';
 import { createIFF } from '@mizdra/inline-fixture-files';
 
 const fixtureDir = join(tmpdir(), 'inline-fs-fixtures', process.env['VITEST_POOL_ID']!);
+
+beforeEach(async () => {
+  await rm(fixtureDir, { recursive: true, force: true });
+});
 
 test('eslint reports lint errors', async () => {
   const iff = await createIFF(

--- a/example/eslint.test.ts
+++ b/example/eslint.test.ts
@@ -1,12 +1,17 @@
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import dedent from 'dedent';
 import { ESLint } from 'eslint';
-import { expect, test } from 'vitest';
+import { expect, test, beforeEach } from 'vitest';
 import { createIFF } from '../src/index.js';
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const fixtureDir = join(tmpdir(), 'inline-fs-fixtures', process.env['VITEST_POOL_ID']!);
+
+beforeEach(async () => {
+  await rm(fixtureDir, { recursive: true, force: true });
+});
 
 test('eslint reports lint errors', async () => {
   const iff = await createIFF(

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,26 +83,13 @@ export type CreateIFFOptions = {
   /** Root directory for fixtures. */
   rootDir: string;
   /**
-   * Whether the fixture should be cleaned up before export.
-   * If `'rmRootDir'` is passed, `rmRootDir` is called before writing.
-   * If `'rmFixtures'` is passed, `rmFixtures` is called before writing.
-   * If `false` is passed, no clean-up is done.
-   * @default 'rmRootDir'
-   */
-  cleanUpBeforeWriting?: 'rmRootDir' | 'rmFixtures' | false | undefined;
-  /**
    * If `true`, `createIFF` does not write files.
-   * When this option is `true`, the clean-up process by `cleanUpBeforeWriting` is skipped,
-   * but writing by `CreateIFFResult#addFixtures` is not disabled.
+   * But this option cannot disable writing by `CreateIFFResult#addFixtures`.
    * @default false
    */
   noWrite?: boolean | undefined;
 };
 
-export const DEFAULT_CLEAN_UP_BEFORE_WRITING = 'rmRootDir' satisfies Exclude<
-  CreateIFFOptions['cleanUpBeforeWriting'],
-  undefined
->;
 export const DEFAULT_NO_WRITE = false satisfies Exclude<CreateIFFOptions['noWrite'], undefined>;
 
 /**
@@ -128,7 +115,7 @@ export async function createIFF<const T extends Directory>(
   directory: T,
   options: CreateIFFOptions,
 ): Promise<CreateIFFResult<T>> {
-  const { cleanUpBeforeWriting = DEFAULT_CLEAN_UP_BEFORE_WRITING, noWrite = DEFAULT_NO_WRITE } = options;
+  const { noWrite = DEFAULT_NO_WRITE } = options;
   const rootDir = resolve(options.rootDir); // normalize path
 
   function getRealPath(...paths: string[]): string {
@@ -147,10 +134,6 @@ export async function createIFF<const T extends Directory>(
   }
 
   if (!noWrite) {
-    if (cleanUpBeforeWriting) {
-      if (cleanUpBeforeWriting === 'rmRootDir') await rmRootDir();
-      if (cleanUpBeforeWriting === 'rmFixtures') await rmFixtures();
-    }
     await createIFFImpl(directory, rootDir);
   }
 


### PR DESCRIPTION
The automatic clean-up function will be removed and replaced with a manual style of doing it. This is to keep the library simple.