### PR TITLE
Remove `noWrite` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@ test('eslint reports lint errors', async () => {
 - [CreateIFFResult#rmFixtures][9]
 - [CreateIFFResult#rootDir][10]
 - [CreateIFFOptions#rootDir][11]
-- [CreateIFFOptions#noWrite][12]
-- [AddFixturesResult#paths][13]
+- [AddFixturesResult#paths][12]
 
 ### createIFF
 
@@ -121,7 +120,7 @@ Use of Windows path separator is an undefined behavior.
     ```;
 ````
 
-Returns **[Promise][14]\\&lt;CreateIFFResult\\<T>>** An object that provides functions to manipulate the fixtures.
+Returns **[Promise][13]\\&lt;CreateIFFResult\\<T>>** An object that provides functions to manipulate the fixtures.
 
 ### CreateIFFResult#paths
 
@@ -180,7 +179,6 @@ That is, it is equivalent to `require('path').join(rootDir, ...paths)`.
 ### CreateIFFResult#addFixtures
 
 Add fixtures to `rootDir`.
-This function always performs the write operation regardless of the value of `CreateIFFOptions#noWrite`.
 
 #### Parameters
 
@@ -207,11 +205,6 @@ using `path.resolve`.
 
 Root directory for fixtures.
 
-### CreateIFFOptions#noWrite
-
-If `true`, `createIFF` does not write files.
-But this option cannot disable writing by `CreateIFFResult#addFixtures`.
-
 ### AddFixturesResult#paths
 
 - **See**: CreateIFFResult#paths
@@ -229,6 +222,5 @@ The paths of the added fixtures.
 [9]: #createiffresultrmfixtures
 [10]: #createiffresultrootdir
 [11]: #createiffoptionsrootdir
-[12]: #createiffoptionsnowrite
-[13]: #addfixturesresultpaths
-[14]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[12]: #addfixturesresultpaths
+[13]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -49,15 +49,6 @@ describe('createIFF', () => {
     const iff = await createIFF({ 'a.txt': 'a' }, { rootDir: join(fixtureDir, 'a') });
     expect(iff.join('a.txt')).toBe(join(fixtureDir, 'a/a.txt'));
   });
-  describe('noWrite', () => {
-    test('skip writing if true', async () => {
-      const iff1 = await createIFF({ 'a.txt': 'a' }, { ...options, noWrite: false });
-      expect(await exists(iff1.join('a.txt'))).toBe(true);
-
-      const iff2 = await createIFF({ 'b.txt': 'b' }, { ...options, noWrite: true });
-      expect(await exists(iff2.join('b.txt'))).toBe(false);
-    });
-  });
 });
 
 describe('CreateIFFResult', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,6 @@ export type CreateIFFResult<T extends Directory> = {
   rmFixtures: () => Promise<void>;
   /**
    * Add fixtures to `rootDir`.
-   * This function always performs the write operation regardless of the value of `CreateIFFOptions#noWrite`.
    * @param directory The definition of fixtures to be added.
    * @returns The paths of the added fixtures.
    * @name CreateIFFResult#addFixtures
@@ -97,16 +96,7 @@ export type CreateIFFOptions = {
    * @name CreateIFFOptions#rootDir
    */
   rootDir: string;
-  /**
-   * If `true`, `createIFF` does not write files.
-   * But this option cannot disable writing by `CreateIFFResult#addFixtures`.
-   * @default false
-   * @name CreateIFFOptions#noWrite
-   */
-  noWrite?: boolean | undefined;
 };
-
-export const DEFAULT_NO_WRITE = false satisfies Exclude<CreateIFFOptions['noWrite'], undefined>;
 
 /**
  * Create fixtures in the specified directory.
@@ -131,7 +121,6 @@ export async function createIFF<const T extends Directory>(
   directory: T,
   options: CreateIFFOptions,
 ): Promise<CreateIFFResult<T>> {
-  const { noWrite = DEFAULT_NO_WRITE } = options;
   const rootDir = resolve(options.rootDir); // normalize path
 
   function getRealPath(...paths: string[]): string {
@@ -149,9 +138,7 @@ export async function createIFF<const T extends Directory>(
     return { paths: getPaths(directory, rootDir) };
   }
 
-  if (!noWrite) {
-    await createIFFImpl(directory, rootDir);
-  }
+  await createIFFImpl(directory, rootDir);
 
   return {
     rootDir,


### PR DESCRIPTION
 This is to keep the library simple.